### PR TITLE
Incoming Images

### DIFF
--- a/src/commands/test/test.js
+++ b/src/commands/test/test.js
@@ -1,5 +1,6 @@
 // Flex Command: test
 /*---------- Will Not Be In Final Product ----------*/
+import { EmbedBuilder } from "discord.js";
 
 
 export default {
@@ -11,6 +12,10 @@ export default {
         // Get the highest role from the user
         const highestRole = interaction.member.roles.highest;
         winston.info(highestRole.name);
-        await interaction.editReply({ content: 'Test Complete' });
+        let text = `[Test](https://old.discordjs.dev/#/docs/discord.js/main/class/Message?scrollTo=attachments)`;
+        const embed = new EmbedBuilder()
+            .setTitle(`Test`)
+            .setDescription(text);
+        await interaction.editReply({ embeds: [embed]});
     }
 };

--- a/src/functions/modTicket.js
+++ b/src/functions/modTicket.js
@@ -26,9 +26,11 @@ const modTicket = async (ticket) => {
     let ticketAttachments = ``;
     if (ticket.ticketAttachments.length === 0) {
         ticketAttachments = `No attachments`;
-    } else if (ticket.ticketAttachments.length <= 5) { // Only display 5 or less attachments - safeguard embed limits
+    } else if (ticket.ticketAttachments.length <= 25) { // Only display 25 or less attachments - safeguard embed limits
+        let attachmentCount = 0;
         ticket.ticketAttachments.forEach(attachment => {
-            ticketAttachments += emojis.redDot + attachment + `\n`;
+            attachmentCount++;
+            ticketAttachments += emojis.redDot + `[Link #${attachmentCount}](${attachment})` + `\n`;
         });
     } else {
         ticketAttachments = `Too many attachments to display, please use the \`/viewattach\` command.`;

--- a/src/handlers/interactionHandler.js
+++ b/src/handlers/interactionHandler.js
@@ -138,7 +138,10 @@ const handleInteractionCreate = async (interaction) => {
       const parentChannelId = message.channel.parentId;
       // Handle message based on channel type
       if (message.channel.type === 1){ // Check if message is a DM
-        await incomingDirectMessage(message).catch(err => winston.error("Error in directMessageHandler: ", err));
+        await incomingDirectMessage(message).catch(err => {
+          winston.error(`Error in directMessageHandler: ${err.message}`);
+          winston.debug(`Error stack: ${err.stack}`);
+        });
       } else if (channelIDs.includes(parentChannelId)){ // Check if message is within a ticket forum
         await watchedMessage(message).catch(err => winston.error("Error in messageHandler: ", err));
       } else {


### PR DESCRIPTION
If a user pastes an image directly from their clipboard into a Discord chat, it does not originate from a URL like an image that's shared from a web page. However, when they send the image, Discord automatically uploads it to their CDN (Content Delivery Network), and it is then accessible via a URL. This new URL is what the attachment.url will point to.

- Need to implement this on the addattach command as well.